### PR TITLE
Nominate Haibo Yang as new maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,6 +6,7 @@
 | Yang Feng | fengyangsy | fengyang.09186@h3c.com |
 | Yuanmao Zhu | zhuyuanmao | yuanmao@ualberta.ca |
 | Xichen Pan | xichen1 | xichen.pan@gmail.com  |
+| Haibo Yang | YoungHypo | haiboyang@umail.ucsb.edu  |
 
 ## Release Managers
 


### PR DESCRIPTION
Haibo Yang is one of the intern students in the year 2024. He continues to contribute to the project for more than 3 months after his internship. According to the maintainer rules, we would like to nominate him as a new maintainer.