### PR TITLE
feat: add Apple Silicon (M1/M2/M3) support - Update Dockerfiles for A…

### DIFF
--- a/bootup/docker-compose-files/docker-compose.dev.yml
+++ b/bootup/docker-compose-files/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
     image: hyperledger/cello-dashboard
     container_name: cello-dashboard
     ports:
-      - "${DASHBOARD_SERVICE_PORT}:8081"
+      - "${DASHBOARD_SERVICE_PORT:-8081}:8081"
     networks:
       - cello-net
     depends_on:
@@ -32,7 +32,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ${CELLO_STORAGE_PATH:-/opt/cello}/pgdata:/var/lib/postgresql/data
+      - cello-postgres-data:/var/lib/postgresql/data
     networks:
       - cello-net
 
@@ -58,7 +58,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ${CELLO_STORAGE_PATH:-/opt/cello}:/opt/cello
+      - cello-api-engine-data:/opt/cello
     networks:
       - cello-net
     depends_on:
@@ -77,7 +77,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - DOCKER_URL=unix://var/run/docker.sock
-      - STORAGE_PATH=${CELLO_STORAGE_PATH:-/opt/cello}/hyperledger
+      - STORAGE_PATH=/opt/cello/hyperledger
     networks:
       - cello-net
 
@@ -86,7 +86,7 @@ networks:
     name: cello-net
 
 volumes:
-  cello-api-engine:
-  cello-postgres:
+  cello-postgres-data:
+  cello-api-engine-data:
   cello-dashboard:
   cello-docker-agent:

--- a/build_image/docker/agent/docker-rest-agent/Dockerfile.in
+++ b/build_image/docker/agent/docker-rest-agent/Dockerfile.in
@@ -1,14 +1,28 @@
-FROM python:3.8
+FROM python:3.8-slim
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-dev \
+    libev-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and pip config
 COPY src/agent/docker-rest-agent/requirements.txt /
-ARG pip=pip.conf.bak
+ARG pip=pip.conf
 COPY src/agent/docker-rest-agent/pip.conf /root/.pip/$pip
 
-RUN pip install -r /requirements.txt
-RUN mkdir -p /var/www/server
+# Install Python dependencies with pinned gevent version
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir "gevent==22.10.2" && \
+    pip install --no-cache-dir -r /requirements.txt
 
-COPY src/agent/docker-rest-agent/server.py /var/www/server
-COPY src/agent/docker-rest-agent/gunicorn.conf.py  /var/www/server
+# Create server directory and copy files
+RUN mkdir -p /var/www/server
+COPY src/agent/docker-rest-agent/server.py /var/www/server/
+COPY src/agent/docker-rest-agent/gunicorn.conf.py /var/www/server/
 
 WORKDIR /var/www/server
 
-CMD ["gunicorn", "server:app", "-c", "./gunicorn.conf.py"]
+# Run the server
+CMD ["gunicorn", "--config", "gunicorn.conf.py", "server:app"]

--- a/build_image/docker/common/api-engine/Dockerfile.in
+++ b/build_image/docker/common/api-engine/Dockerfile.in
@@ -1,8 +1,19 @@
-FROM python:3.8
+FROM python:3.8-slim
 
-# Install software
+# Install software including PostgreSQL development packages and pkg-config for pygraphviz
 RUN apt-get update \
-	&& apt-get install -y gettext-base graphviz libgraphviz-dev vim \
+	&& apt-get install -y \
+		gettext-base \
+		graphviz \
+		libgraphviz-dev \
+		pkg-config \
+		vim \
+		curl \
+		postgresql \
+		postgresql-client \
+		libpq-dev \
+		gcc \
+		python3-dev \
 	&& apt-get autoclean \
 	&& apt-get clean \
 	&& apt-get autoremove && rm -rf /var/cache/apt/
@@ -11,14 +22,23 @@ RUN apt-get update \
 WORKDIR /var/www/server
 
 # Install compiled code tools from Artifactory and copy it to opt folder.
-RUN curl -L --retry 5 --retry-delay 3 "https://github.com/hyperledger/fabric/releases/download/v2.5.10/hyperledger-fabric-linux-amd64-2.5.10.tar.gz" | tar xz -C /opt/
+# Use platform-specific Fabric binary
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+		curl -L --retry 5 --retry-delay 3 "https://github.com/hyperledger/fabric/releases/download/v2.5.10/hyperledger-fabric-linux-arm64-2.5.10.tar.gz" | tar xz -C /opt/; \
+	else \
+		curl -L --retry 5 --retry-delay 3 "https://github.com/hyperledger/fabric/releases/download/v2.5.10/hyperledger-fabric-linux-amd64-2.5.10.tar.gz" | tar xz -C /opt/; \
+	fi
 
 # Copy source code to the working dir
 COPY src/api-engine ./
 COPY template/node  /opt/node
 
 # Install python dependencies
-RUN	pip3 install -r requirements.txt
+# First upgrade pip to latest version
+RUN pip3 install --no-cache-dir --upgrade pip && \
+	pip3 install --no-cache-dir psycopg2-binary==2.8.4 && \
+	pip3 install --no-cache-dir -r requirements.txt
 
 # Add uwsgi configuration file
 COPY build_image/docker/common/api-engine/server.ini /etc/uwsgi/apps-enabled/


### PR DESCRIPTION
This PR adds support for Apple Silicon (M1/M2/M3) Macs by:

- Updating Dockerfiles to use python:3.8-slim base image for better ARM64 compatibility
- Adding build dependencies for gevent and other packages
- Pinning gevent to version 22.10.2 for Python 3.8 compatibility
- Updating docker-compose.dev.yml to use named volumes instead of host mounts
- Fixing platform-specific build issues for ARM64 architecture

Changes have been tested on:
- M3 Pro Macbook Pro (ARM64)
- Verified backward compatibility with existing AMD64 setup

Key improvements:
1. Platform Detection: Improved detection of architecture for Docker builds
2. Multi-arch Support: Using python:3.8-slim for ARM64 and AMD64
3. Backward Compatibility: Maintained support for AMD64 users
4. Performance: Enabled native ARM64 builds on Apple Silicon without emulation

Done/Closes #681