### PR TITLE
Stop building images twice for every update

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -16,9 +16,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-      - name: Install dependencies
+      - name: Set up Nodejs
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
+      - name: Install Nodejs dependencies
+        run: |
+          yarn install --frozen-lockfile
       - name: Check code
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,7 @@ check: ##@Code Check code format
 	@$(MAKE) license
 	find ./docs -type f -name "*.md" -exec egrep -l " +$$" {} \;
 	cd src/api-engine && tox && cd ${ROOT_PATH}
-	make docker-compose
-	MODE=dev make start
-	sleep 10
-	MODE=dev make stop
-	make check-dashboard
+	cd src/dashboard && yarn lint && cd ${ROOT_PATH}
 
 deep-clean: ##@Clean Stop services, clean docker images and remove mounted local storage.
 	make clean-images


### PR DESCRIPTION
Previously, the images will be built twice since `make check` will also build the images. This is redundant for checking code format and removed from the Makefile now.