### PR TITLE
Allow orderers to be removed when the organization network is None

### DIFF
--- a/src/api-engine/api/routes/node/views.py
+++ b/src/api-engine/api/routes/node/views.py
@@ -611,12 +611,10 @@ class NodeViewSet(viewsets.ViewSet):
                         continue
                     break
             if res:
-                fabric_path = "{}/{}".format(FABRIC_NODE,
-                                                infos["container_name"])
+                fabric_path = "{}/{}".format(FABRIC_NODE, infos["container_name"])
                 if os.path.exists(fabric_path):
                     shutil.rmtree(fabric_path, True)
-                prod_path = "{}/{}".format(PRODUCTION_NODE,
-                                            infos["container_name"])
+                prod_path = "{}/{}".format(PRODUCTION_NODE, infos["container_name"])
                 if os.path.exists(prod_path):
                     shutil.rmtree(prod_path, True)
                 node.delete()


### PR DESCRIPTION
Users couldn't remove an orderer once it had been added to a network. This creates a deadlock an invalid orderer could never be removed. This commit fixes this by allow users to remove the orderer once the network is None.

Fixes #690