### PR TITLE
Create handleSelectRows implementations

### DIFF
--- a/src/dashboard/src/pages/ChainCode/ChainCode.js
+++ b/src/dashboard/src/pages/ChainCode/ChainCode.js
@@ -186,6 +186,12 @@ class ChainCode extends PureComponent {
     this.setState({ newFile: file });
   };
 
+  handleSelectRows = rows => {
+    this.setState({
+      selectedRows: rows,
+    });
+  };
+
   render() {
     const {
       selectedRows,

--- a/src/dashboard/src/pages/Channel/Channel.js
+++ b/src/dashboard/src/pages/Channel/Channel.js
@@ -479,6 +479,12 @@ class Channel extends PureComponent {
     });
   };
 
+  handleSelectRows = rows => {
+    this.setState({
+      selectedRows: rows,
+    });
+  };
+
   render() {
     const { selectedRows, modalVisible, channelData, updateModalVisible, newFile } = this.state;
     const {

--- a/src/dashboard/src/pages/Network/Network.js
+++ b/src/dashboard/src/pages/Network/Network.js
@@ -110,6 +110,12 @@ class Network extends PureComponent {
     }
   };
 
+  handleSelectRows = rows => {
+    this.setState({
+      selectedRows: rows,
+    });
+  };
+
   render() {
     const { selectedRows } = this.state;
     const {


### PR DESCRIPTION
Currently, users can't select multiple rows on network, channel, and chaincode pages because the classes don't implement the `handleSelectRows` function.

This commit provides the necessary implementations to those classes.