### PR TITLE
Stop showing api URL on UI for errors

### DIFF
--- a/src/dashboard/src/utils/request.js
+++ b/src/dashboard/src/utils/request.js
@@ -31,7 +31,6 @@ const errorHandler = error => {
           id: 'error.login.invalidCredentials',
           defaultMessage: 'Invalid username or password.',
         }),
-        description: url,
       });
       return;
     }
@@ -41,7 +40,6 @@ const errorHandler = error => {
         id: 'error.login.expired',
         defaultMessage: 'Not logged in or session expired. Please log in again.',
       }),
-      description: url,
     });
     history.replace({
       pathname: '/user/login',
@@ -60,7 +58,6 @@ const errorHandler = error => {
           id: 'error.register.duplicate',
           defaultMessage: 'Email address or organization name already exists.',
         }),
-        description: url,
       });
       return;
     }


### PR DESCRIPTION
Users don't have to know the URI details. Such behaviors provide bad UX for confusing people.