### PR TITLE
Remove redundant request interceptor

### DIFF
--- a/src/dashboard/src/utils/request.js
+++ b/src/dashboard/src/utils/request.js
@@ -127,23 +127,4 @@ request.interceptors.request.use(async (url, options) => {
   };
 });
 
-// 第一个拦截器有可能返回Promise,那么Promise由第二个拦截器处理
-request.interceptors.request.use(async (url, options) => {
-  const token = localStorage.getItem('cello-token');
-  if (url.indexOf('api/v1/login') < 0 && url.indexOf('api/v1/register') < 0 && token) {
-    // 如果有token 就走token逻辑
-    const headers = {
-      Authorization: `JWT ${token}`,
-    };
-    return {
-      url,
-      options: { ...options, headers },
-    };
-  }
-  return {
-    url,
-    options,
-  };
-});
-
 export default request;


### PR DESCRIPTION
Originally there were two identical request interceptors, both adding the JWT token header except for login and register requests.

However, umi-request's interceptors chain supports async functions naturally, and the Promise returned by the first interceptor is properly handled without needing a second interceptor to process it.

Therefore, the second interceptor is redundant and can be safely removed without affecting functionality, simplifying the codebase.