### PR TITLE
Remove CA from node type

### DIFF
--- a/src/dashboard/src/pages/Node/index.js
+++ b/src/dashboard/src/pages/Node/index.js
@@ -230,7 +230,7 @@ const CreateNode = props => {
     },
   };
 
-  const types = ['ca', 'orderer', 'peer'];
+  const types = ['orderer', 'peer'];
   const typeOptions = types.map(item => (
     <Option value={item} key={item}>
       <span style={{ color: '#8c8f88' }}>{item}</span>


### PR DESCRIPTION
Currently `api-engine` doesn't support CA fully. Remove it from node creation form to prevent users from misclicking.