### PR TITLE
feat: add .devcontainer configuration for Codespaces and VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:1": {},
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "lts"
+      "version": "20"
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.10"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "Hyperledger Cello",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.10"
+    }
+  },
+  "containerEnv": {
+    "CELLO_STORAGE_PATH": "/opt/cello"
+  },
+  "forwardPorts": [8080, 8081],
+  "portsAttributes": {
+    "8080": {
+      "label": "API Engine",
+      "onAutoForward": "notify"
+    },
+    "8081": {
+      "label": "Dashboard",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "make local",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "ms-python.python",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a `.devcontainer/devcontainer.json` configuration to provide a automated, zero-setup development environment for Hyperledger Cello using GitHub Codespaces or VS Code Dev Containers.

## Problem
Currently, new contributors must manually install Docker, Docker Compose, Node.js, and Python, as well as configure environment variables before running the project stack locally. This friction slows down first-time contributions.

## Solution & Proposed Changes
Adds `.devcontainer/devcontainer.json` with the following configuration:
- **Pre-installed Runtimes & Tools**:
  - `docker-in-docker:1` (Docker daemon and `docker compose` support inside the container)
  - `node:1` (Node.js LTS for frontend dashboard development)
  - `python:1` (Python 3.10 for API engine backend)
- **Automatic Environment Setup**:
  - Automatically sets `CELLO_STORAGE_PATH=/opt/cello`
  - Automatically executes `make local` as a `postCreateCommand` so the local stack is built and running upon first launch
- **Port Forwarding**:
  - Exposes port `8080` (API Engine)
  - Exposes port `8081` (Dashboard)
- **VS Code Extensions**:
  - Includes Docker, Python, and ESLint extensions pre-configured.

## How to Test
1. Open this repository branch in **GitHub Codespaces** or open locally in **VS Code** with the *Dev Containers* extension installed.
2. Select **"Reopen in Container"**.
3. Verify that the container builds, `make local` runs, and ports `8080` & `8081` become available automatically.
