### PR TITLE
fix: EnumWithDisplayMeta dict compatibility and chaincode schema

### DIFF
--- a/src/api-engine/api/common/enums.py
+++ b/src/api-engine/api/common/enums.py
@@ -75,8 +75,12 @@ class EnumWithDisplayMeta(EnumMeta):
 
         if display_strings is not None and inspect.isclass(display_strings):
             del attrs["DisplayStrings"]
-            if hasattr(attrs, "_member_names"):
-                attrs._member_names.remove("DisplayStrings")
+            member_names = getattr(attrs, "_member_names", None)
+            if member_names is not None and "DisplayStrings" in member_names:
+                try:
+                    member_names.remove("DisplayStrings")
+                except (AttributeError, TypeError):
+                    pass
 
         obj = super().__new__(mcs, name, bases, attrs)
         for m in obj:

--- a/src/api-engine/chaincode/migrations/0003_alter_chaincode_sequence.py
+++ b/src/api-engine/chaincode/migrations/0003_alter_chaincode_sequence.py
@@ -20,4 +20,14 @@ class Migration(migrations.Migration):
                 validators=[MinValueValidator(1)],
             ),
         ),
+        migrations.AlterField(
+            model_name='chaincode',
+            name='signature_policy',
+            field=models.CharField(
+                blank=True,
+                help_text='Chaincode Signature Policy',
+                max_length=1024,
+                null=True,
+            ),
+        ),
     ]

--- a/src/api-engine/chaincode/models.py
+++ b/src/api-engine/chaincode/models.py
@@ -76,6 +76,7 @@ class Chaincode(models.Model):
     )
     signature_policy = models.CharField(
         help_text="Chaincode Signature Policy",
+        max_length=1024,
         null=True,
         blank=True,
     )


### PR DESCRIPTION
- Fix hasattr check for _member_names on dict attrs in EnumWithDisplayMeta
- Add explicit max_length=1024 on Chaincode.signature_policy CharField
- Add migration for chaincode sequence default value and signature_policy max_length