### PR TITLE
fix: correct pagination total extraction in modelFactory

### DIFF
--- a/src/dashboard/src/utils/modelFactory.js
+++ b/src/dashboard/src/utils/modelFactory.js
@@ -67,7 +67,7 @@ export function createListEffect({ service, namespace, dataKey, getTotalFromResp
     const current = payload?.page || pagination.current;
 
     // Support custom total extraction (e.g., response.data.total vs response.total)
-    const total = getTotalFromResponse ? getTotalFromResponse(response) : response.total;
+    const total = getTotalFromResponse ? getTotalFromResponse(response) : response.data?.total;
 
     yield put({
       type: 'save',


### PR DESCRIPTION
Fix getTotalFromResponse fallback from response.total to response.data?.total. The API engine wraps responses in {data: {total: N, data: [...]}}, so response.total was always undefined, breaking pagination for all models without custom getTotalFromResponse.