### PR TITLE
feat(agent): add read-only node logs endpoint

### DIFF
--- a/src/agents/hyperledger-fabric/node/serializers.py
+++ b/src/agents/hyperledger-fabric/node/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from node.enums import NodeType
-from node.service import create_node, get_node_status
+from node.service import create_node, get_node_logs, get_node_status
 
 
 class NodeRequestSerializer(serializers.Serializer):
@@ -38,4 +38,26 @@ class NodeStatusRequestSerializer(serializers.Serializer):
     def create(self, validated_data) -> NodeStatusSerializer:
         status = get_node_status(validated_data["type"], validated_data["name"])
         return NodeStatusSerializer(dict(status=status))
+
+
+class NodeLogsResponseSerializer(serializers.Serializer):
+    logs = serializers.CharField(help_text="Node logs (last N lines)")
+
+
+class NodeLogsRequestSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(
+        help_text="Node Type",
+        choices=[(node_type.name, node_type.name) for node_type in NodeType])
+    name = serializers.CharField(help_text="Node Name")
+    tail = serializers.IntegerField(
+        help_text="Number of log lines to return",
+        required=False,
+        default=200,
+        min_value=1,
+        max_value=1000,
+    )
+
+    def create(self, validated_data) -> NodeLogsResponseSerializer:
+        logs = get_node_logs(validated_data["type"], validated_data["name"], validated_data.get("tail", 200))
+        return NodeLogsResponseSerializer(dict(logs=logs))
 

--- a/src/agents/hyperledger-fabric/node/service.py
+++ b/src/agents/hyperledger-fabric/node/service.py
@@ -27,6 +27,18 @@ def get_node_status(node_type: str, name: str) -> str:
             crypto_config["PeerOrgs" if node_type == NodeType.PEER.name else "OrdererOrgs"][0]["Domain"])).status
 
 
+def get_node_logs(node_type: str, name: str, tail: int = 200) -> str:
+    with open(CRYPTO_CONFIG, "r", encoding="utf-8") as f:
+        crypto_config = yaml.safe_load(f)
+    domain = crypto_config["PeerOrgs" if node_type == NodeType.PEER.name else "OrdererOrgs"][0]["Domain"]
+    container_name = f"{name}.{domain}"
+    container = docker_client.containers.get(container_name)
+    raw = container.logs(tail=tail, timestamps=False)
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
 def create_node(node_type: str, name: str) -> bytes:
     return _create_node(NodeType.PEER if node_type == NodeType.PEER.name else NodeType.ORDERER, name)
 

--- a/src/agents/hyperledger-fabric/node/tests.py
+++ b/src/agents/hyperledger-fabric/node/tests.py
@@ -1,3 +1,78 @@
-from django.test import TestCase
+from unittest.mock import MagicMock, mock_open, patch
 
-# Create your tests here.
+import docker
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from node.serializers import NodeLogsRequestSerializer
+from node.views import NodeViewSet
+
+CRYPTO_YAML = "PeerOrgs:\n  - Domain: org1.example.com\nOrdererOrgs:\n  - Domain: orderer.example.com\n"
+
+
+class NodeLogsServiceTests(TestCase):
+    @patch("node.service.open", new_callable=mock_open, read_data=CRYPTO_YAML)
+    @patch("node.service.docker_client")
+    def test_get_node_logs_returns_decoded_string(self, mock_docker, _mock_open):
+        mock_container = MagicMock()
+        mock_container.logs.return_value = b"line1\nline2\n"
+        mock_docker.containers.get.return_value = mock_container
+
+        from node.service import get_node_logs
+
+        logs = get_node_logs("PEER", "peer0", tail=10)
+        self.assertEqual(logs, "line1\nline2\n")
+        mock_docker.containers.get.assert_called_once_with("peer0.org1.example.com")
+        mock_container.logs.assert_called_once_with(tail=10, timestamps=False)
+
+    @patch("node.service.open", new_callable=mock_open, read_data=CRYPTO_YAML)
+    @patch("node.service.docker_client")
+    def test_get_node_logs_orderer_domain(self, mock_docker, _mock_open):
+        mock_container = MagicMock()
+        mock_container.logs.return_value = b"orderer log"
+        mock_docker.containers.get.return_value = mock_container
+
+        from node.service import get_node_logs
+
+        logs = get_node_logs("ORDERER", "orderer0")
+        self.assertEqual(logs, "orderer log")
+        mock_docker.containers.get.assert_called_once_with("orderer0.orderer.example.com")
+
+
+class NodeLogsSerializerTests(TestCase):
+    def test_valid_with_defaults(self):
+        s = NodeLogsRequestSerializer(data={"type": "PEER", "name": "peer0"})
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["tail"], 200)
+
+    def test_tail_bounds(self):
+        s = NodeLogsRequestSerializer(data={"type": "PEER", "name": "peer0", "tail": 0})
+        self.assertFalse(s.is_valid())
+        s = NodeLogsRequestSerializer(data={"type": "PEER", "name": "peer0", "tail": 1001})
+        self.assertFalse(s.is_valid())
+        s = NodeLogsRequestSerializer(data={"type": "PEER", "name": "peer0", "tail": 50})
+        self.assertTrue(s.is_valid(), s.errors)
+
+
+class NodeLogsViewTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.view = NodeViewSet.as_view({"get": "logs"})
+
+    @patch("node.serializers.get_node_logs", return_value="some logs")
+    def test_logs_returns_200(self, _mock_logs):
+        request = self.factory.get("/api/v1/nodes/logs?type=PEER&name=peer0&tail=10")
+        response = self.view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["logs"], "some logs")
+
+    def test_logs_missing_params_returns_400(self):
+        request = self.factory.get("/api/v1/nodes/logs?type=PEER")
+        response = self.view(request)
+        self.assertEqual(response.status_code, 400)
+
+    @patch("node.serializers.get_node_logs", side_effect=docker.errors.NotFound("not found"))
+    def test_logs_not_found_returns_404(self, _mock_logs):
+        request = self.factory.get("/api/v1/nodes/logs?type=PEER&name=missing")
+        response = self.view(request)
+        self.assertEqual(response.status_code, 404)

--- a/src/agents/hyperledger-fabric/node/views.py
+++ b/src/agents/hyperledger-fabric/node/views.py
@@ -1,10 +1,11 @@
+import docker
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from node.serializers import NodeRequestSerializer, NodeResponseSerializer, NodeStatusRequestSerializer, \
-    NodeStatusSerializer
+from node.serializers import NodeLogsRequestSerializer, NodeLogsResponseSerializer, NodeRequestSerializer, \
+    NodeResponseSerializer, NodeStatusRequestSerializer, NodeStatusSerializer
 
 
 # Create your views here.
@@ -21,6 +22,21 @@ class NodeViewSet(viewsets.ViewSet):
         return Response(
             data=serializer.save().data,
             status=status.HTTP_200_OK)
+
+    @extend_schema(
+        parameters=[NodeLogsRequestSerializer],
+        responses={200: NodeLogsResponseSerializer}
+    )
+    @action(detail=False, methods=['get'], url_path='logs')
+    def logs(self, request):
+        serializer = NodeLogsRequestSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        try:
+            data = serializer.save().data
+        except docker.errors.NotFound as exc:
+            return Response(data={"detail": str(exc)}, status=status.HTTP_404_NOT_FOUND)
+
+        return Response(data=data, status=status.HTTP_200_OK)
 
 
     @extend_schema(


### PR DESCRIPTION
Implements GET /api/v1/nodes/logs?type=PEER&name=<name>&tail=<n> on the Fabric agent, prerequisite for copilot fault-log summarization. Uses docker logs with bounded tail (1..1000, default 200) and maps NotFound to 404. Adds serializer validation and view tests.

Part of #813 — prerequisite for @agamatlab's fault-log summarization tool (#3 in the 
  work split).                                                                         
                                                                                     
  ## What this does                                                                    
                                                            
  Adds `GET /api/v1/nodes/logs?type=PEER&name=<name>&tail=<n>` to the Fabric agent   
  (`src/agents/hyperledger-fabric/`). Returns the last N lines of Docker container logs
   for a given node.
                                                                                       
  - `get_node_logs()` in `service.py` — same pattern as the existing 
  `get_node_status()`: reads `CRYPTO_CONFIG` YAML, resolves container name from org    
  domain, calls `container.logs(tail=tail)`
  - `NodeLogsRequestSerializer` — validates `type` (PEER/ORDERER), `name`, and `tail`  
  (1–1000, default 200)                                                                
  - `NodeLogsResponseSerializer` — `{ logs: str }`                                   
  - `NodeViewSet.logs` action — `@action(detail=False, methods=['get'],                
  url_path='logs')`, maps `docker.errors.NotFound` to 404                              
  - 7 tests covering the service function, serializer bounds, and view responses     
  (200/400/404)                                                                        
                                                            
  ## Why separate PR                                                                   
                                                            
  The logs endpoint is a Fabric agent change with no overlap with the dashboard panel 
  or the copilot endpoint. Keeping it separate so it can be reviewed and merged        
  independently without waiting on the larger copilot pieces.
  EOF                                                                                  
  )"                        