### PR TITLE
feat(api-engine): streaming copilot chat endpoint

### DIFF
--- a/.github/workflows/api-engine-unit-tests.yml
+++ b/.github/workflows/api-engine-unit-tests.yml
@@ -1,0 +1,37 @@
+name: API Engine Unit Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Only the database and the API engine. The copilot tests mock both the
+      # LLM and Cello's REST API, so no key or external service is needed, but
+      # Django's test runner still builds a test database.
+      - name: Start DB and API Engine
+        run: docker compose -f docker-compose.dev.yaml up -d --build cello-postgres cello-api-engine
+
+      - name: Wait for Postgres
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec cello-postgres pg_isready -U postgres >/dev/null 2>&1; then
+              echo "Postgres is ready"; exit 0
+            fi
+            echo "Waiting for Postgres ($i/30)..."; sleep 2
+          done
+          echo "Postgres did not become ready in time"; exit 1
+
+      - name: Run api-engine unit tests
+        run: docker exec cello-api-engine python manage.py test copilot
+
+      - name: Stop DB and API Engine
+        if: always()
+        run: docker compose -f docker-compose.dev.yaml down -v

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -45,6 +45,15 @@ services:
       - DEBUG=True
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - FABRIC_LOGGING_SPEC=INFO
+      # Cello copilot. Unset by default, so /api/v1/copilot/chat answers 503
+      # until a key and a model are provided. The base URL and the model pick
+      # the vendor together, for example DeepSeek:
+      #   CELLO_COPILOT_LLM_BASE_URL=https://api.deepseek.com
+      #   CELLO_COPILOT_LLM_MODEL=deepseek-chat
+      - CELLO_COPILOT_LLM_API_KEY=${CELLO_COPILOT_LLM_API_KEY:-}
+      - CELLO_COPILOT_LLM_BASE_URL=${CELLO_COPILOT_LLM_BASE_URL:-}
+      - CELLO_COPILOT_LLM_MODEL=${CELLO_COPILOT_LLM_MODEL:-}
+      - CELLO_COPILOT_LLM_PROVIDER=${CELLO_COPILOT_LLM_PROVIDER:-openai_compatible}
     ports:
       - "8080:8080"
     volumes:

--- a/src/api-engine/api_engine/settings.py
+++ b/src/api-engine/api_engine/settings.py
@@ -54,8 +54,39 @@ INSTALLED_APPS = [
     "organization.apps.OrganizationConfig",
     "node.apps.NodeConfig",
     "channel.apps.ChannelConfig",
-    "chaincode.apps.ChaincodeConfig"
+    "chaincode.apps.ChaincodeConfig",
+    "copilot.apps.CopilotConfig"
 ]
+
+# --------------------------------------------------------------------------
+# Cello copilot (read-only chat). Every value comes from the environment, so no
+# key is ever committed. The copilot stays off until CELLO_COPILOT_LLM_API_KEY
+# and CELLO_COPILOT_LLM_MODEL are both set; until then the endpoint answers 503.
+#
+# The default provider speaks the OpenAI chat-completions protocol, which most
+# vendors implement, so the base URL and the model choose the vendor together.
+# For DeepSeek:
+#   CELLO_COPILOT_LLM_BASE_URL=https://api.deepseek.com
+#   CELLO_COPILOT_LLM_MODEL=deepseek-chat
+# Leaving the base URL empty falls back to the SDK default (api.openai.com), in
+# which case the model has to be an OpenAI one. There is no default model for
+# that reason: the right value depends on where the base URL points.
+# --------------------------------------------------------------------------
+CELLO_COPILOT_LLM_PROVIDER = os.environ.get(
+    "CELLO_COPILOT_LLM_PROVIDER", "openai_compatible"
+)
+CELLO_COPILOT_LLM_MODEL = os.environ.get("CELLO_COPILOT_LLM_MODEL", "")
+CELLO_COPILOT_LLM_BASE_URL = os.environ.get("CELLO_COPILOT_LLM_BASE_URL", "")
+CELLO_COPILOT_LLM_API_KEY = os.environ.get("CELLO_COPILOT_LLM_API_KEY", "")
+CELLO_COPILOT_MAX_TOKENS = int(os.environ.get("CELLO_COPILOT_MAX_TOKENS", "1024"))
+CELLO_COPILOT_MAX_TOOL_ITERATIONS = int(
+    os.environ.get("CELLO_COPILOT_MAX_TOOL_ITERATIONS", "8")
+)
+# The REST API root the copilot's tools call, over loopback by default. The
+# caller's JWT is forwarded to it, so the copilot acts as the logged-in user.
+CELLO_COPILOT_API_BASE = os.environ.get(
+    "CELLO_COPILOT_API_BASE", "http://localhost:8080/api/v1"
+)
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",

--- a/src/api-engine/api_engine/urls.py
+++ b/src/api-engine/api_engine/urls.py
@@ -27,6 +27,7 @@ from rest_framework_simplejwt.views import (
 )
 from django.conf.urls.static import static
 from api_engine.settings import DEBUG, WEBROOT
+from copilot.views import ChatView
 from auth.views import RegisterViewSet, CelloTokenObtainPairView, CelloTokenVerifyView
 from chaincode.views import ChaincodeViewSet
 from channel.views import ChannelViewSet, InvitationViewSet
@@ -64,6 +65,7 @@ urlpatterns = [path(WEBROOT, include(router.urls + [
     ),
     path("login/refresh", TokenRefreshView.as_view(), name="token_refresh"),
     path("token-verify", CelloTokenVerifyView.as_view(), name="token_verify"),
+    path("copilot/chat", ChatView.as_view(), name="copilot_chat"),
     path("docs", schema_view.with_ui("swagger", cache_timeout=0), name="docs"),
     path("redoc", schema_view.with_ui("redoc", cache_timeout=0), name="redoc"),
 ]))]

--- a/src/api-engine/copilot/__init__.py
+++ b/src/api-engine/copilot/__init__.py
@@ -1,0 +1,3 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#

--- a/src/api-engine/copilot/apps.py
+++ b/src/api-engine/copilot/apps.py
@@ -1,0 +1,9 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from django.apps import AppConfig
+
+
+class CopilotConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "copilot"

--- a/src/api-engine/copilot/client.py
+++ b/src/api-engine/copilot/client.py
@@ -1,0 +1,163 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Read-only queries against Cello's REST API.
+
+The caller supplies the API root and an ``Authorization`` header value, so this
+module has no opinion about where the token comes from. The copilot forwards the
+end user's JWT; the MCP server in ``src/mcp-server/`` logs in with a service
+account and holds its own. Both need the same five queries, which is why they
+live here rather than inside either caller.
+
+No function raises. Failures come back as ``{"ok": False, "error": ...}`` so an
+LLM sees a message it can explain instead of the request aborting. Callers that
+want an exception can check the flag.
+"""
+import requests
+
+TIMEOUT = 30.0
+HEALTH_TIMEOUT = 10.0
+
+# common.serializers.PageQuerySerializer rejects a per_page above this.
+MAX_PER_PAGE = 100
+
+
+def error(message, detail="", hint=""):
+    payload = {"ok": False, "error": message}
+    if detail:
+        payload["detail"] = detail
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def get(api_base, auth_header, path, params=None):
+    """Authenticated GET against the Cello REST API.
+
+    Returns ``{"ok": True, "data": <parsed body>}`` or an error dict.
+    """
+    if not auth_header:
+        return error(
+            "No Authorization header to forward",
+            hint="This client must be called on behalf of an authenticated user.",
+        )
+    url = "%s/%s" % (api_base.rstrip("/"), path.lstrip("/"))
+    try:
+        resp = requests.get(
+            url,
+            headers={"Authorization": auth_header},
+            params=params,
+            timeout=TIMEOUT,
+        )
+    except requests.exceptions.ConnectionError as exc:
+        return error(
+            "Cello API is not reachable",
+            detail=str(exc),
+            hint="Verify the API Engine is running and the API base is correct.",
+        )
+    except requests.exceptions.Timeout as exc:
+        return error("Cello API request timed out", detail=str(exc))
+    except requests.exceptions.RequestException as exc:
+        return error("Cello API request failed", detail=str(exc))
+
+    if resp.status_code == 401:
+        return error(
+            "Cello rejected the request (HTTP 401)",
+            detail=resp.text[:500],
+            hint="The session token may be expired or lack permission.",
+        )
+    if resp.status_code >= 400:
+        return error(
+            "Cello API returned HTTP %s" % resp.status_code,
+            detail=resp.text[:500],
+            hint="Check the request and the Cello server state.",
+        )
+    try:
+        return {"ok": True, "data": resp.json()}
+    except ValueError:
+        return error(
+            "Cello returned a non-JSON response",
+            detail=resp.text[:500],
+            hint="Check the API base points at the API root.",
+        )
+
+
+# --------------------------------------------------------------------------
+# List envelope. Cello wraps list payloads as
+# {"status", "msg", "data": {"total": N, "data": [...]}} via common.responses.ok.
+# ``get`` nests that under body["data"], so unwrapping is two levels. The lookups
+# below are deliberately lenient: an upstream shape change should degrade to an
+# empty list rather than raise inside a tool call.
+# --------------------------------------------------------------------------
+
+
+def _envelope(body):
+    payload = body.get("data", {})
+    inner = payload.get("data", payload) if isinstance(payload, dict) else {}
+    return inner if isinstance(inner, dict) else {}
+
+
+def items(body):
+    inner = _envelope(body).get("data", [])
+    return inner if isinstance(inner, list) else []
+
+
+def total(body):
+    """Total count reported by Cello, falling back to the page length."""
+    reported = _envelope(body).get("total")
+    return int(reported) if isinstance(reported, int) else len(items(body))
+
+
+def _listing(api_base, auth_header, path, key, limit):
+    body = get(
+        api_base, auth_header, path, params={"per_page": min(limit, MAX_PER_PAGE)}
+    )
+    if not body.get("ok"):
+        return body
+    page = items(body)[:limit]
+    return {"ok": True, "count": len(page), "total": total(body), key: page}
+
+
+def list_nodes(api_base, auth_header, limit=50):
+    return _listing(api_base, auth_header, "nodes", "nodes", limit)
+
+
+def list_channels(api_base, auth_header, limit=50):
+    return _listing(api_base, auth_header, "channels", "channels", limit)
+
+
+def list_chaincodes(api_base, auth_header, limit=50):
+    return _listing(api_base, auth_header, "chaincodes", "chaincodes", limit)
+
+
+def list_organizations(api_base, auth_header, limit=50):
+    return _listing(api_base, auth_header, "organizations", "organizations", limit)
+
+
+def check_health(api_base):
+    """Is the API Engine answering? Unauthenticated, so it works before login."""
+    url = "%s/docs" % api_base.rstrip("/")
+    try:
+        resp = requests.get(url, timeout=HEALTH_TIMEOUT)
+    except requests.exceptions.Timeout as exc:
+        return error(
+            "Cello API health check timed out",
+            detail=str(exc),
+            hint="The API Engine may be starting up or overloaded.",
+        )
+    except requests.exceptions.RequestException as exc:
+        return error(
+            "Cello API is not reachable",
+            detail=str(exc),
+            hint="Start Cello with `make local` and verify the API base.",
+        )
+
+    healthy = 200 <= resp.status_code < 400
+    payload = {"ok": healthy, "reachable": True, "status": resp.status_code}
+    if not healthy:
+        payload["hint"] = (
+            "Reachable but returning server errors; check the API Engine logs."
+            if resp.status_code >= 500
+            else "Reachable but returned a client error; verify the API base."
+        )
+    return payload

--- a/src/api-engine/copilot/llm.py
+++ b/src/api-engine/copilot/llm.py
@@ -1,0 +1,350 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tool-calling loop for the Cello copilot.
+
+The provider is not fixed. ``CELLO_COPILOT_LLM_PROVIDER`` picks a runner out of
+``_PROVIDERS`` and the SDK is imported lazily, so only the configured provider's
+package has to be installed. The bundled runner speaks the OpenAI
+chat-completions protocol, which most vendors implement, so pointing
+``CELLO_COPILOT_LLM_BASE_URL`` at DeepSeek, OpenRouter, Together, Groq or a local
+Ollama is a config change rather than a code change. A vendor with its own
+protocol adds one ``_stream_x`` function here plus a schema converter in
+``copilot.tools``.
+
+The loop is a generator of events:
+
+    user message
+      -> model (with tool schemas), streaming text back token by token
+        -> while the model asks for a tool: run it, feed the result back
+          -> a final ``done`` event carrying the whole reply
+
+``run_agent`` drains that generator for callers that only want the final answer,
+so there is one loop rather than a streaming copy and a blocking copy.
+"""
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List
+
+from django.conf import settings
+
+from copilot.tools import ToolContext, openai_tool_schemas, run_tool
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = (
+    "You are the Cello operations assistant, embedded in the Hyperledger "
+    "Cello dashboard. You help an operator inspect their Hyperledger Fabric "
+    "deployment (nodes, channels, chaincodes, organizations). "
+    "You are READ-ONLY: you can look things up via tools but cannot create, "
+    "modify or delete anything. If asked to make a change, explain that "
+    "write operations are not yet supported and point to the dashboard. "
+    "Prefer calling a tool over guessing. Answer concisely; when you list "
+    "resources, summarize counts and notable items rather than dumping raw "
+    "JSON."
+)
+
+# The values the ``done`` frame may carry, per the contract in #813. Anything
+# else a provider reports is normalized to "stop" so clients can switch on a
+# closed set. "length" means the model was cut off by max_tokens.
+STOP_REASONS = frozenset(
+    ["stop", "end_turn", "length", "max_iterations", "error"]
+)
+
+
+class AgentConfigError(RuntimeError):
+    """Misconfiguration, such as a missing API key. A 5xx, not a user error."""
+
+
+class AgentUpstreamError(RuntimeError):
+    """The LLM provider rejected or failed the call.
+
+    Bad key, rate limit, unknown model, unreachable endpoint. Providers raise
+    their own SDK exceptions and each runner translates them into this one, so
+    the view never imports a provider SDK just to catch its errors.
+    """
+
+
+@dataclass
+class ToolCallTrace:
+    name: str
+    input: dict
+    output: dict
+
+
+@dataclass
+class AgentResult:
+    reply: str
+    tool_calls: List[ToolCallTrace] = field(default_factory=list)
+    stop_reason: str = "end_turn"
+
+
+@dataclass
+class Event:
+    """One SSE frame: ``name`` is the event type, ``data`` its JSON payload."""
+
+    name: str
+    data: Dict[str, Any]
+
+
+@dataclass
+class _Config:
+    model: str
+    max_tokens: int
+    max_iterations: int
+
+
+def _config() -> _Config:
+    model = getattr(settings, "CELLO_COPILOT_LLM_MODEL", "")
+    if not model:
+        raise AgentConfigError(
+            "CELLO_COPILOT_LLM_MODEL is not set. It has no safe default: the "
+            "right value depends on which vendor CELLO_COPILOT_LLM_BASE_URL "
+            "points at."
+        )
+    return _Config(
+        model=model,
+        max_tokens=int(getattr(settings, "CELLO_COPILOT_MAX_TOKENS", 1024)),
+        max_iterations=int(
+            getattr(settings, "CELLO_COPILOT_MAX_TOOL_ITERATIONS", 8)
+        ),
+    )
+
+
+def _normalize_stop(reason: str) -> str:
+    return reason if reason in STOP_REASONS else "stop"
+
+
+# --------------------------------------------------------------------------
+# OpenAI-compatible provider, against any vendor implementing the
+# chat-completions protocol at CELLO_COPILOT_LLM_BASE_URL.
+# --------------------------------------------------------------------------
+
+
+def _get_client():
+    """Build the chat-completions client, or raise ``AgentConfigError``."""
+    api_key = getattr(settings, "CELLO_COPILOT_LLM_API_KEY", "")
+    if not api_key:
+        raise AgentConfigError(
+            "CELLO_COPILOT_LLM_API_KEY is not set; the copilot cannot reach "
+            "the LLM."
+        )
+    try:
+        import openai
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise AgentConfigError("The 'openai' package is not installed.") from exc
+
+    kwargs = {"api_key": api_key}
+    # An empty base URL means "use the SDK default" (api.openai.com). Any other
+    # value points at a compatible vendor.
+    base_url = getattr(settings, "CELLO_COPILOT_LLM_BASE_URL", "")
+    if base_url:
+        kwargs["base_url"] = base_url
+    return openai.OpenAI(**kwargs)
+
+
+def _drain(stream, state: dict) -> Iterator[str]:
+    """Yield assistant text as it arrives, collecting tool calls into ``state``.
+
+    Tool calls arrive split across chunks: the id and function name land in the
+    first delta for a given index and the JSON arguments dribble in after, so
+    each field is concatenated rather than assigned.
+    """
+    calls = state.setdefault("calls", {})
+    for chunk in stream:
+        if not chunk.choices:
+            continue
+        choice = chunk.choices[0]
+        if choice.finish_reason:
+            state["finish_reason"] = choice.finish_reason
+        delta = choice.delta
+        if delta is None:
+            continue
+
+        text = getattr(delta, "content", None)
+        if text:
+            state["content"] = state.get("content", "") + text
+            yield text
+
+        for part in getattr(delta, "tool_calls", None) or []:
+            slot = calls.setdefault(
+                part.index, {"id": "", "name": "", "arguments": ""}
+            )
+            if part.id:
+                slot["id"] = part.id
+            function = getattr(part, "function", None)
+            if function is None:
+                continue
+            if function.name:
+                slot["name"] += function.name
+            if function.arguments:
+                slot["arguments"] += function.arguments
+
+
+def _stream_openai_compatible(
+    messages: List[dict], context: ToolContext
+) -> Iterator[Event]:
+    client = _get_client()
+    cfg = _config()
+    schemas = openai_tool_schemas()
+    convo = [{"role": "system", "content": SYSTEM_PROMPT}, *messages]
+    trace: List[ToolCallTrace] = []
+
+    import openai  # _get_client already proved this imports
+
+    for _ in range(cfg.max_iterations):
+        try:
+            stream = client.chat.completions.create(
+                model=cfg.model,
+                max_tokens=cfg.max_tokens,
+                tools=schemas,
+                messages=convo,
+                stream=True,
+            )
+            state: dict = {}
+            for text in _drain(stream, state):
+                yield Event("token", {"text": text})
+        except openai.APIError as exc:
+            # Covers auth, rate limit, unknown model and connection failures.
+            logger.warning("Cello copilot LLM call failed: %s", exc)
+            raise AgentUpstreamError(str(exc)) from exc
+
+        calls = [state["calls"][i] for i in sorted(state.get("calls", {}))]
+        content = state.get("content", "")
+
+        if not calls:
+            yield Event(
+                "done",
+                _done_payload(
+                    content.strip(),
+                    trace,
+                    _normalize_stop(state.get("finish_reason") or "stop"),
+                ),
+            )
+            return
+
+        # Echo the assistant's tool-call turn back, then answer each call.
+        convo.append(
+            {
+                "role": "assistant",
+                "content": content or None,
+                "tool_calls": [
+                    {
+                        "id": call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["name"],
+                            "arguments": call["arguments"] or "{}",
+                        },
+                    }
+                    for call in calls
+                ],
+            }
+        )
+        for call in calls:
+            try:
+                params = json.loads(call["arguments"] or "{}")
+            except ValueError:
+                # A model can emit malformed JSON. Run the tool with no
+                # arguments rather than dropping the call.
+                params = {}
+            yield Event(
+                "tool_call",
+                {"id": call["id"], "name": call["name"], "input": params},
+            )
+            output = run_tool(call["name"], params, context)
+            trace.append(
+                ToolCallTrace(name=call["name"], input=params, output=output)
+            )
+            yield Event(
+                "tool_result",
+                {
+                    "id": call["id"],
+                    "name": call["name"],
+                    "ok": bool(output.get("ok", True)),
+                    "output": output,
+                },
+            )
+            convo.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call["id"],
+                    "content": json.dumps(output),
+                }
+            )
+
+    logger.warning(
+        "Cello copilot hit max tool iterations (%s) without finishing",
+        cfg.max_iterations,
+    )
+    yield Event(
+        "done",
+        _done_payload(
+            "I wasn't able to finish that within the allowed number of steps. "
+            "Please narrow the question and try again.",
+            trace,
+            "max_iterations",
+        ),
+    )
+
+
+def _done_payload(reply, trace, stop_reason):
+    return {
+        "reply": reply,
+        "stop_reason": stop_reason,
+        "tool_calls": [
+            {"name": t.name, "input": t.input, "output": t.output} for t in trace
+        ],
+    }
+
+
+# --------------------------------------------------------------------------
+# Provider registry. A vendor with its own protocol adds a runner here and a
+# schema converter in copilot.tools; the tool layer itself does not change.
+# --------------------------------------------------------------------------
+
+_PROVIDERS: Dict[str, Callable[[List[dict], ToolContext], Iterator[Event]]] = {
+    "openai_compatible": _stream_openai_compatible,
+}
+
+
+def stream_agent(messages: List[dict], context: ToolContext) -> Iterator[Event]:
+    """Run the tool-calling loop, yielding events as they happen.
+
+    ``messages`` is the running conversation in role/content form. ``context``
+    carries the caller's auth header and the Cello API root, and scopes every
+    tool call. The last event of a successful turn is always ``done``.
+    """
+    provider = getattr(
+        settings, "CELLO_COPILOT_LLM_PROVIDER", "openai_compatible"
+    )
+    runner = _PROVIDERS.get(provider)
+    if runner is None:
+        raise AgentConfigError(
+            "Unsupported CELLO_COPILOT_LLM_PROVIDER '%s'. Supported: %s."
+            % (provider, ", ".join(sorted(_PROVIDERS)))
+        )
+    return runner(messages, context)
+
+
+def run_agent(messages: List[dict], context: ToolContext) -> AgentResult:
+    """Run the loop to completion and return only the final answer.
+
+    Kept for callers that have no use for intermediate events. It drives the
+    same generator as the streaming path, so the two cannot drift.
+    """
+    final = None
+    for event in stream_agent(messages, context):
+        if event.name == "done":
+            final = event.data
+    if final is None:  # pragma: no cover - a runner that never finishes
+        raise AgentUpstreamError("The provider ended the turn without a reply.")
+    return AgentResult(
+        reply=final["reply"],
+        tool_calls=[
+            ToolCallTrace(name=c["name"], input=c["input"], output=c["output"])
+            for c in final["tool_calls"]
+        ],
+        stop_reason=final["stop_reason"],
+    )

--- a/src/api-engine/copilot/serializers.py
+++ b/src/api-engine/copilot/serializers.py
@@ -1,0 +1,51 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+from rest_framework import serializers
+
+
+class ChatMessageSerializer(serializers.Serializer):
+    ROLE_CHOICES = ("user", "assistant")
+    role = serializers.ChoiceField(choices=ROLE_CHOICES)
+    content = serializers.CharField(allow_blank=False, trim_whitespace=False)
+
+
+class ChatRequestBody(serializers.Serializer):
+    """Request body for POST /api/v1/copilot/chat.
+
+    The client sends the whole conversation each turn and the server keeps no
+    state between requests. The last message has to come from the user, since
+    there is nothing for the model to answer otherwise.
+    """
+
+    messages = serializers.ListField(
+        child=ChatMessageSerializer(),
+        allow_empty=False,
+        min_length=1,
+        help_text="Conversation so far, oldest first.",
+    )
+
+    def validate_messages(self, value):
+        if value[-1]["role"] != "user":
+            raise serializers.ValidationError(
+                "The last message must have role 'user'."
+            )
+        return value
+
+
+class ToolCallSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    input = serializers.DictField()
+    output = serializers.DictField()
+
+
+class ChatDoneEvent(serializers.Serializer):
+    """Payload of the final ``done`` frame.
+
+    Declared for the generated API docs, which cannot describe an event stream.
+    A client that only wants the answer can read this frame and skip the rest.
+    """
+
+    reply = serializers.CharField()
+    stop_reason = serializers.CharField()
+    tool_calls = ToolCallSerializer(many=True)

--- a/src/api-engine/copilot/sse.py
+++ b/src/api-engine/copilot/sse.py
@@ -1,0 +1,132 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Server-sent event plumbing for the copilot chat endpoint.
+
+Two jobs. Formatting events as SSE frames is the easy one. The other is
+keepalives: a turn that calls a slow tool can go quiet for a while, and an idle
+connection is exactly what an intermediate proxy likes to drop. Emitting a
+comment line on a timer means the request thread has to stay responsive while
+the model is busy, so the loop runs on a worker thread and hands events back
+through a queue.
+
+The worker only makes HTTP calls (to the LLM and to Cello's REST API) and never
+touches the ORM, so it needs no database connection of its own.
+"""
+import json
+import logging
+import queue
+import threading
+
+logger = logging.getLogger(__name__)
+
+KEEPALIVE_SECONDS = 15.0
+
+# How long to hold the response open before committing to a status code. Past
+# this the stream starts and later failures arrive as an ``error`` frame, since
+# the status line has already gone out.
+FIRST_EVENT_TIMEOUT = 15.0
+
+_QUEUE_DEPTH = 64
+
+
+def frame(name, data):
+    """One SSE frame. Compact separators keep tool payloads from bloating."""
+    body = json.dumps(data, separators=(",", ":"), default=str)
+    return "event: %s\ndata: %s\n\n" % (name, body)
+
+
+def comment(text="ping"):
+    """A comment line. Not an event, so a client parser skips it."""
+    return ": %s\n\n" % text
+
+
+class EventStream:
+    """Drives an event generator on a worker thread.
+
+    ``first`` waits for the opening event so the view can still answer with a
+    real status code if the turn fails immediately. ``frames`` then yields SSE
+    text, inserting a keepalive whenever the worker goes quiet.
+    """
+
+    def __init__(self, source, keepalive=KEEPALIVE_SECONDS):
+        self._source = source
+        self._keepalive = keepalive
+        self._queue = queue.Queue(maxsize=_QUEUE_DEPTH)
+        self._thread = threading.Thread(
+            target=self._produce, name="copilot-stream", daemon=True
+        )
+        self._replay = []
+        self._finished = False
+
+    def _produce(self):
+        try:
+            for event in self._source:
+                self._queue.put(("event", event))
+        except Exception as exc:  # noqa: BLE001 - re-raised on the reader side
+            self._queue.put(("error", exc))
+        finally:
+            self._queue.put(("end", None))
+
+    def start(self):
+        self._thread.start()
+
+    def first(self, timeout=FIRST_EVENT_TIMEOUT):
+        """The first item, or ``None`` if the worker is still thinking.
+
+        Anything taken off the queue here is replayed by ``frames``, so calling
+        this does not consume the event.
+        """
+        try:
+            item = self._queue.get(timeout=timeout)
+        except queue.Empty:
+            return None
+        self._replay.append(item)
+        return item
+
+    def frames(self):
+        """SSE text for the whole turn, keepalives included."""
+        for item in self._replay:
+            for text in self._render(item):
+                yield text
+        self._replay = []
+
+        while not self._finished:
+            try:
+                item = self._queue.get(timeout=self._keepalive)
+            except queue.Empty:
+                yield comment()
+                continue
+            for text in self._render(item):
+                yield text
+
+    def _render(self, item):
+        kind, payload = item
+        if kind == "event":
+            yield frame(payload.name, payload.data)
+        elif kind == "error":
+            self._finished = True
+            logger.warning("Cello copilot stream failed: %s", payload)
+            yield frame("error", error_payload(payload))
+        else:
+            self._finished = True
+
+
+def error_payload(exc):
+    """An ``error`` frame body. The code names the class of failure."""
+    from copilot.llm import AgentConfigError, AgentUpstreamError
+
+    if isinstance(exc, AgentConfigError):
+        return {
+            "code": "not_configured",
+            "message": "The copilot is not configured: %s" % exc,
+        }
+    if isinstance(exc, AgentUpstreamError):
+        return {
+            "code": "upstream_error",
+            "message": "The LLM provider could not be reached: %s" % exc,
+        }
+    return {
+        "code": "internal_error",
+        "message": "The copilot failed to answer.",
+    }

--- a/src/api-engine/copilot/tests.py
+++ b/src/api-engine/copilot/tests.py
@@ -1,0 +1,498 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tests for the read-only Cello copilot.
+
+Nothing here touches the network or needs an API key. The LLM client is always a
+stub and the tools' HTTP calls to Cello are mocked. What is asserted:
+
+* the client issues the right authenticated GET and unwraps Cello's envelope
+* streamed tool calls are reassembled from deltas split across chunks
+* the loop drives tools and then answers, in the frame order the contract states
+* the provider comes from a registry rather than being hardcoded
+* the base URL is forwarded, which is what lets one runner serve many vendors
+* a failure before the first byte is a status code, and after it a frame
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import AccessToken
+
+from organization.models import Organization
+from user.models import UserProfile
+from copilot import client, llm, sse, tools
+from copilot.llm import (
+    AgentConfigError,
+    AgentUpstreamError,
+    Event,
+    run_agent,
+    stream_agent,
+)
+
+SETTINGS = {
+    "CELLO_COPILOT_LLM_API_KEY": "k",
+    "CELLO_COPILOT_LLM_MODEL": "deepseek-chat",
+}
+
+
+def _ctx():
+    return tools.ToolContext(
+        auth_header="JWT test-token", api_base="http://api/api/v1"
+    )
+
+
+def _rest_response(status_code=200, payload=None, text=""):
+    """A fake ``requests`` response carrying only what the client reads."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    if payload is None:
+        resp.json.side_effect = ValueError("no json")
+    else:
+        resp.json.return_value = payload
+    return resp
+
+
+def _list_envelope(items, total=None):
+    """Cello's list envelope: {status, msg, data: {total, data: [...]}}."""
+    return {
+        "status": "SUCCESSFUL",
+        "msg": None,
+        "data": {
+            "total": total if total is not None else len(items),
+            "data": items,
+        },
+    }
+
+
+def _chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+    )
+
+
+def _call_delta(index=0, call_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _text_turn(text, finish_reason="stop"):
+    """A plain answer, split so the streaming path is actually exercised."""
+    return [_chunk(content=part) for part in text.split(" ")] + [
+        _chunk(finish_reason=finish_reason)
+    ]
+
+
+def _tool_turn(name, params, call_id="call_1"):
+    """A tool-call turn with the arguments split across two chunks.
+
+    Providers send the id and name once and then dribble the JSON in, so
+    splitting here is what the accumulator has to survive.
+    """
+    arguments = json.dumps(params)
+    half = len(arguments) // 2
+    return [
+        _chunk(tool_calls=[_call_delta(call_id=call_id, name=name)]),
+        _chunk(tool_calls=[_call_delta(arguments=arguments[:half])]),
+        _chunk(tool_calls=[_call_delta(arguments=arguments[half:])]),
+        _chunk(finish_reason="tool_calls"),
+    ]
+
+
+def _stub_client(*turns):
+    stub = MagicMock()
+    stub.chat.completions.create.side_effect = list(turns)
+    return stub
+
+
+class ClientTests(TestCase):
+    @patch("copilot.client.requests.get")
+    def test_list_nodes_forwards_auth_and_unwraps_envelope(self, get):
+        get.return_value = _rest_response(
+            payload=_list_envelope(
+                [{"name": "peer0", "type": "peer"},
+                 {"name": "orderer0", "type": "orderer"}]
+            )
+        )
+        out = client.list_nodes("http://api/api/v1", "JWT test-token")
+
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["count"], 2)
+        self.assertEqual(out["total"], 2)
+        self.assertEqual(
+            {n["name"] for n in out["nodes"]}, {"peer0", "orderer0"}
+        )
+        args, kwargs = get.call_args
+        self.assertEqual(args[0], "http://api/api/v1/nodes")
+        self.assertEqual(kwargs["headers"], {"Authorization": "JWT test-token"})
+
+    @patch("copilot.client.requests.get")
+    def test_limit_is_capped_at_the_server_maximum(self, get):
+        get.return_value = _rest_response(payload=_list_envelope([]))
+        client.list_nodes("http://api/api/v1", "JWT t", limit=5000)
+        self.assertEqual(get.call_args.kwargs["params"]["per_page"], 100)
+
+    @patch("copilot.client.requests.get")
+    def test_http_error_becomes_a_structured_error(self, get):
+        get.return_value = _rest_response(status_code=403, text="forbidden")
+        out = client.list_nodes("http://api/api/v1", "JWT t")
+        self.assertFalse(out["ok"])
+        self.assertIn("403", out["error"])
+
+    @patch("copilot.client.requests.get")
+    def test_non_json_body_becomes_a_structured_error(self, get):
+        get.return_value = _rest_response(text="<html>nope</html>")
+        out = client.list_nodes("http://api/api/v1", "JWT t")
+        self.assertFalse(out["ok"])
+
+    def test_missing_auth_header_is_an_error(self):
+        out = client.list_nodes("http://api/api/v1", "")
+        self.assertFalse(out["ok"])
+
+    @patch("copilot.client.requests.get")
+    def test_health_check_needs_no_token(self, get):
+        get.return_value = _rest_response(payload={})
+        out = client.check_health("http://api/api/v1")
+        self.assertTrue(out["ok"])
+        self.assertNotIn("headers", get.call_args.kwargs)
+
+
+class ToolRegistryTests(TestCase):
+    def test_every_registered_tool_is_read_only(self):
+        names = {t.name for t in tools.get_tools()}
+        self.assertEqual(
+            names,
+            {
+                "list_nodes",
+                "list_channels",
+                "list_chaincodes",
+                "list_organizations",
+                "check_health",
+            },
+        )
+
+    def test_unknown_tool_raises(self):
+        with self.assertRaises(tools.UnknownToolError):
+            tools.run_tool("delete_everything", {}, _ctx())
+
+    @patch("copilot.tools.client.list_nodes", side_effect=RuntimeError("boom"))
+    def test_a_failing_tool_does_not_abort_the_turn(self, _):
+        out = tools.run_tool("list_nodes", {}, _ctx())
+        self.assertFalse(out["ok"])
+        self.assertIn("boom", out["detail"])
+
+    def test_schemas_are_well_formed(self):
+        schemas = tools.openai_tool_schemas()
+        self.assertEqual(len(schemas), len(tools.get_tools()))
+        for schema in schemas:
+            self.assertEqual(schema["type"], "function")
+            self.assertIn("description", schema["function"])
+            self.assertEqual(schema["function"]["parameters"]["type"], "object")
+
+
+class StreamAgentTests(TestCase):
+    def _events(self, *turns):
+        with self.settings(**SETTINGS):
+            with patch("copilot.llm._get_client", return_value=_stub_client(*turns)):
+                return list(stream_agent([{"role": "user", "content": "hi"}], _ctx()))
+
+    @patch("copilot.client.requests.get")
+    def test_tool_call_is_reassembled_from_split_deltas(self, get):
+        get.return_value = _rest_response(
+            payload=_list_envelope([{"name": "peer0"}])
+        )
+        events = self._events(
+            _tool_turn("list_nodes", {"limit": 10}),
+            _text_turn("You have one node."),
+        )
+        call = next(e for e in events if e.name == "tool_call")
+        self.assertEqual(call.data["name"], "list_nodes")
+        self.assertEqual(call.data["input"], {"limit": 10})
+
+    @patch("copilot.client.requests.get")
+    def test_frame_order_matches_the_contract(self, get):
+        get.return_value = _rest_response(payload=_list_envelope([]))
+        events = self._events(
+            _tool_turn("list_nodes", {}), _text_turn("No nodes.")
+        )
+        order = [e.name for e in events]
+        self.assertEqual(order[0], "tool_call")
+        self.assertEqual(order[1], "tool_result")
+        self.assertEqual(order[-1], "done")
+        # tool_result carries the id of the tool_call it answers.
+        self.assertEqual(events[0].data["id"], events[1].data["id"])
+        # Tokens only ever appear before the done frame.
+        self.assertTrue(all(e.name == "token" for e in events[2:-1]))
+
+    def test_tokens_stream_before_the_done_frame(self):
+        events = self._events(_text_turn("two peers are up"))
+        tokens = [e.data["text"] for e in events if e.name == "token"]
+        self.assertEqual(len(tokens), 4)
+        done = events[-1]
+        self.assertEqual(done.name, "done")
+        self.assertEqual(done.data["reply"], "twopeersareup")
+        self.assertEqual(done.data["stop_reason"], "stop")
+
+    @patch("copilot.client.requests.get")
+    def test_max_iterations_guard_ends_the_turn(self, get):
+        get.return_value = _rest_response(payload=_list_envelope([]))
+        stub = MagicMock()
+        stub.chat.completions.create.side_effect = (
+            lambda **kwargs: iter(_tool_turn("list_nodes", {}))
+        )
+        with self.settings(CELLO_COPILOT_MAX_TOOL_ITERATIONS=3, **SETTINGS):
+            with patch("copilot.llm._get_client", return_value=stub):
+                events = list(
+                    stream_agent([{"role": "user", "content": "loop"}], _ctx())
+                )
+        self.assertEqual(events[-1].data["stop_reason"], "max_iterations")
+        self.assertEqual(stub.chat.completions.create.call_count, 3)
+
+    def test_unexpected_finish_reason_is_normalized(self):
+        events = self._events(_text_turn("hi", finish_reason="content_filter"))
+        self.assertEqual(events[-1].data["stop_reason"], "stop")
+
+    def test_truncation_is_reported_rather_than_hidden(self):
+        events = self._events(_text_turn("hi", finish_reason="length"))
+        self.assertEqual(events[-1].data["stop_reason"], "length")
+
+    def test_provider_errors_become_upstream_errors(self):
+        import openai
+
+        stub = MagicMock()
+        stub.chat.completions.create.side_effect = openai.APIError(
+            "bad key", request=MagicMock(), body=None
+        )
+        with self.settings(**SETTINGS):
+            with patch("copilot.llm._get_client", return_value=stub):
+                with self.assertRaises(AgentUpstreamError):
+                    list(stream_agent([{"role": "user", "content": "hi"}], _ctx()))
+
+    def test_missing_api_key_raises_config_error(self):
+        with self.settings(CELLO_COPILOT_LLM_API_KEY=""):
+            with self.assertRaises(AgentConfigError):
+                list(stream_agent([{"role": "user", "content": "hi"}], _ctx()))
+
+    def test_missing_model_raises_config_error(self):
+        """No default model is possible: it depends on the base URL's vendor."""
+        with self.settings(
+            CELLO_COPILOT_LLM_API_KEY="k", CELLO_COPILOT_LLM_MODEL=""
+        ):
+            with self.assertRaises(AgentConfigError):
+                list(stream_agent([{"role": "user", "content": "hi"}], _ctx()))
+
+
+class RunAgentTests(TestCase):
+    """The blocking helper has to agree with the stream it drains."""
+
+    @patch("copilot.client.requests.get")
+    def test_returns_the_final_answer_and_the_trace(self, get):
+        get.return_value = _rest_response(
+            payload=_list_envelope([{"name": "peer0"}])
+        )
+        stub = _stub_client(
+            _tool_turn("list_nodes", {}), _text_turn("One node: peer0.")
+        )
+        with self.settings(**SETTINGS):
+            with patch("copilot.llm._get_client", return_value=stub):
+                result = run_agent([{"role": "user", "content": "nodes?"}], _ctx())
+
+        self.assertEqual(result.stop_reason, "stop")
+        self.assertIn("peer0", result.reply)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].name, "list_nodes")
+
+
+class ClientConfigTests(TestCase):
+    """The base URL is what makes the runner vendor-agnostic, so pin it."""
+
+    @patch("openai.OpenAI")
+    def test_base_url_is_forwarded_when_set(self, openai_cls):
+        with self.settings(
+            CELLO_COPILOT_LLM_API_KEY="k",
+            CELLO_COPILOT_LLM_BASE_URL="https://api.deepseek.com",
+        ):
+            llm._get_client()
+        self.assertEqual(
+            openai_cls.call_args.kwargs["base_url"], "https://api.deepseek.com"
+        )
+
+    @patch("openai.OpenAI")
+    def test_base_url_is_omitted_when_empty(self, openai_cls):
+        """An empty base URL has to fall through to the SDK default rather than
+        be passed as an empty string, which the client rejects."""
+        with self.settings(
+            CELLO_COPILOT_LLM_API_KEY="k", CELLO_COPILOT_LLM_BASE_URL=""
+        ):
+            llm._get_client()
+        self.assertNotIn("base_url", openai_cls.call_args.kwargs)
+
+
+class ProviderSelectionTests(TestCase):
+    def test_registered_provider_is_dispatched_to(self):
+        """Providers are looked up by name. This is the seam a second protocol
+        plugs into without the tool layer changing."""
+        sentinel = [Event("done", {"reply": "stub", "stop_reason": "stop",
+                                   "tool_calls": []})]
+        with patch.dict(llm._PROVIDERS, {"stub": lambda m, c: iter(sentinel)}):
+            with self.settings(CELLO_COPILOT_LLM_PROVIDER="stub"):
+                result = run_agent([{"role": "user", "content": "hi"}], _ctx())
+        self.assertEqual(result.reply, "stub")
+
+    def test_unknown_provider_raises_config_error(self):
+        with self.settings(CELLO_COPILOT_LLM_PROVIDER="does-not-exist"):
+            with self.assertRaises(AgentConfigError):
+                stream_agent([{"role": "user", "content": "hi"}], _ctx())
+
+
+class SseFramingTests(TestCase):
+    def test_frame_shape(self):
+        text = sse.frame("token", {"text": "hi"})
+        self.assertEqual(text, 'event: token\ndata: {"text":"hi"}\n\n')
+
+    def test_comments_are_not_events(self):
+        self.assertEqual(sse.comment(), ": ping\n\n")
+
+    def test_keepalive_is_emitted_while_the_worker_is_quiet(self):
+        import time
+
+        def slow():
+            time.sleep(0.25)
+            yield Event("done", {"reply": "late"})
+
+        stream = sse.EventStream(slow(), keepalive=0.05)
+        stream.start()
+        output = list(stream.frames())
+        self.assertIn(": ping\n\n", output)
+        self.assertTrue(output[-1].startswith("event: done"))
+
+    def test_a_failure_mid_stream_becomes_an_error_frame(self):
+        def explodes():
+            yield Event("token", {"text": "hi"})
+            raise AgentUpstreamError("provider went away")
+
+        stream = sse.EventStream(explodes())
+        stream.start()
+        output = "".join(stream.frames())
+        self.assertIn("event: error", output)
+        self.assertIn("upstream_error", output)
+        self.assertNotIn("event: done", output)
+
+
+class ChatEndpointTests(APITestCase):
+    url = "/api/v1/copilot/chat"
+
+    def setUp(self):
+        self.org = Organization.objects.create(
+            name="OrgA", agent_url="http://agent.example.com:5001"
+        )
+        self.user = UserProfile.objects.create(
+            username="alice", email="alice@example.com", organization=self.org
+        )
+        token = str(AccessToken.for_user(self.user))
+        self.client.credentials(HTTP_AUTHORIZATION="JWT %s" % token)
+
+    def _post(self, content="hi"):
+        return self.client.post(
+            self.url,
+            {"messages": [{"role": "user", "content": content}]},
+            format="json",
+        )
+
+    def _body(self, response):
+        return b"".join(response.streaming_content).decode()
+
+    def test_requires_auth(self):
+        self.client.credentials()
+        self.assertEqual(self._post().status_code, 401)
+
+    def test_rejects_empty_messages(self):
+        resp = self.client.post(self.url, {"messages": []}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_last_message_must_be_from_the_user(self):
+        resp = self.client.post(
+            self.url,
+            {"messages": [{"role": "assistant", "content": "hi"}]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @patch("copilot.views.stream_agent")
+    def test_happy_path_streams_sse(self, stream):
+        stream.return_value = iter(
+            [
+                Event("token", {"text": "two peers"}),
+                Event(
+                    "done",
+                    {
+                        "reply": "two peers",
+                        "stop_reason": "stop",
+                        "tool_calls": [],
+                    },
+                ),
+            ]
+        )
+        resp = self._post("how many peers?")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp["Content-Type"], "text/event-stream; charset=utf-8"
+        )
+        self.assertEqual(resp["Cache-Control"], "no-cache")
+        self.assertEqual(resp["X-Accel-Buffering"], "no")
+
+        body = self._body(resp)
+        self.assertIn("event: token", body)
+        self.assertTrue(body.rstrip().endswith('"tool_calls":[]}'))
+        # The caller's own JWT reaches the tool context.
+        self.assertTrue(
+            stream.call_args.kwargs["context"].auth_header.startswith("JWT ")
+        )
+
+    @patch("copilot.views.stream_agent")
+    def test_unconfigured_is_a_503_before_the_stream_opens(self, stream):
+        def unconfigured():
+            raise AgentConfigError("no key")
+            yield  # pragma: no cover - makes this a generator
+
+        stream.return_value = unconfigured()
+        resp = self._post()
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.data["status"], "FAILED")
+
+    @patch("copilot.views.stream_agent")
+    def test_upstream_failure_is_a_502_not_a_traceback(self, stream):
+        """A bad key must not surface as an unhandled 500. With DEBUG on,
+        Django's error page would echo settings back to the caller."""
+
+        def unreachable():
+            raise AgentUpstreamError("Error code: 401 - invalid api key")
+            yield  # pragma: no cover - makes this a generator
+
+        stream.return_value = unreachable()
+        resp = self._post()
+        self.assertEqual(resp.status_code, 502)
+        self.assertEqual(resp.data["status"], "FAILED")
+
+    @patch("copilot.views.stream_agent")
+    def test_failure_after_the_first_token_arrives_as_a_frame(self, stream):
+        """Once the status line is out, an error can only be an event."""
+
+        def dies_midway():
+            yield Event("token", {"text": "checking"})
+            raise AgentUpstreamError("connection reset")
+
+        stream.return_value = dies_midway()
+        resp = self._post()
+        self.assertEqual(resp.status_code, 200)
+        body = self._body(resp)
+        self.assertIn("event: error", body)
+        self.assertIn("upstream_error", body)

--- a/src/api-engine/copilot/tools.py
+++ b/src/api-engine/copilot/tools.py
@@ -1,0 +1,163 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Tool registry the copilot exposes to the model.
+
+The registry holds names, descriptions and JSON schemas. The queries themselves
+are in ``copilot.client``, which knows nothing about LLMs, so a second caller
+(the MCP server) can use them without dragging this layer along.
+
+Every tool is read-only. Write tools stay out until API-key auth and RBAC land
+(#764, #798), which is the posture agreed in #813.
+"""
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+from copilot import client
+
+
+@dataclass
+class ToolContext:
+    """What a tool needs from the request, without the request itself.
+
+    ``auth_header`` is the caller's own ``Authorization`` header, forwarded
+    verbatim, so Cello scopes every response by the logged-in user exactly as it
+    does for the dashboard. ``api_base`` is the API root, for example
+    ``http://localhost:8080/api/v1``.
+    """
+
+    auth_header: str
+    api_base: str
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    input_schema: dict
+    func: Callable[..., dict]
+
+
+class UnknownToolError(KeyError):
+    pass
+
+
+_REGISTRY: Dict[str, Tool] = {}
+
+_LIMIT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "limit": {
+            "type": "integer",
+            "description": "Maximum items to return (default 50).",
+        }
+    },
+    "required": [],
+}
+
+_NO_ARGS_SCHEMA = {"type": "object", "properties": {}, "required": []}
+
+
+def tool(name, description, input_schema=None):
+    """Register a tool callable as ``func(context, **params)``."""
+
+    def decorator(func):
+        _REGISTRY[name] = Tool(
+            name=name,
+            description=description,
+            input_schema=input_schema or _NO_ARGS_SCHEMA,
+            func=func,
+        )
+        return func
+
+    return decorator
+
+
+def get_tools() -> List[Tool]:
+    return list(_REGISTRY.values())
+
+
+def openai_tool_schemas() -> List[dict]:
+    """Tool definitions shaped for the OpenAI chat-completions API.
+
+    This sits beside the registry rather than inside the provider runner so a
+    vendor with a different schema format adds one converter over the same
+    ``Tool`` objects and nothing else moves.
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.input_schema,
+            },
+        }
+        for t in _REGISTRY.values()
+    ]
+
+
+def run_tool(name: str, params: dict, context: ToolContext) -> dict:
+    """Execute a registered tool, or raise ``UnknownToolError``.
+
+    A tool that blows up returns a structured error instead of propagating, so
+    one bad call does not abort the turn. The model reads the error and can say
+    what went wrong or try something else.
+    """
+    if name not in _REGISTRY:
+        raise UnknownToolError(name)
+    try:
+        return _REGISTRY[name].func(context, **(params or {}))
+    except Exception as exc:  # noqa: BLE001 - handed to the model, not raised
+        return {
+            "ok": False,
+            "error": "tool '%s' failed" % name,
+            "detail": str(exc),
+        }
+
+
+@tool(
+    "list_nodes",
+    "List the blockchain nodes (peers and orderers) visible to the caller, "
+    "with name, type and status.",
+    _LIMIT_SCHEMA,
+)
+def list_nodes(context, limit=50):
+    return client.list_nodes(context.api_base, context.auth_header, limit)
+
+
+@tool(
+    "list_channels",
+    "List the Fabric channels visible to the caller.",
+    _LIMIT_SCHEMA,
+)
+def list_channels(context, limit=50):
+    return client.list_channels(context.api_base, context.auth_header, limit)
+
+
+@tool(
+    "list_chaincodes",
+    "List the deployed chaincodes visible to the caller, with name and version.",
+    _LIMIT_SCHEMA,
+)
+def list_chaincodes(context, limit=50):
+    return client.list_chaincodes(context.api_base, context.auth_header, limit)
+
+
+@tool(
+    "list_organizations",
+    "List the organizations visible to the caller.",
+    _LIMIT_SCHEMA,
+)
+def list_organizations(context, limit=50):
+    return client.list_organizations(context.api_base, context.auth_header, limit)
+
+
+@tool(
+    "check_health",
+    "Check whether the Cello API Engine is reachable and answering. Use this "
+    "when another tool reports a connection failure.",
+    _NO_ARGS_SCHEMA,
+)
+def check_health(context):
+    return client.check_health(context.api_base)

--- a/src/api-engine/copilot/views.py
+++ b/src/api-engine/copilot/views.py
@@ -1,0 +1,105 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Chat endpoint for the Cello copilot.
+
+``POST /api/v1/copilot/chat``, JWT protected, answering as a server-sent event
+stream. The contract the dashboard panel is built against is written up in #813.
+
+The copilot forwards the caller's own ``Authorization`` header to Cello's REST
+API, so it sees exactly what that user is allowed to see. Scoping is inherited
+from the existing API rather than reimplemented here, and there is no service
+account to over-privilege.
+
+Errors land in one of two places. Until the first byte goes out the status line
+is still ours, so a bad body is a 400, missing auth a 401, a missing API key a
+503 and an unreachable provider a 502. After that the response is already a 200
+and a failure can only arrive as an ``error`` frame.
+"""
+from django.conf import settings
+from django.http import StreamingHttpResponse
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from api.common import err
+from copilot import sse
+from copilot.llm import AgentConfigError, AgentUpstreamError, stream_agent
+from copilot.serializers import ChatDoneEvent, ChatRequestBody
+from copilot.tools import ToolContext
+
+
+class ChatView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @swagger_auto_schema(
+        operation_summary="Chat with the Cello copilot (read-only)",
+        operation_description=(
+            "Answers as a text/event-stream. Frames are `token`, `tool_call`, "
+            "`tool_result` and a final `done`, or a single `error` frame if the "
+            "turn fails after the stream has opened. The schema below is the "
+            "body of the `done` frame."
+        ),
+        request_body=ChatRequestBody,
+        responses={status.HTTP_200_OK: ChatDoneEvent},
+    )
+    def post(self, request):
+        body = ChatRequestBody(data=request.data)
+        body.is_valid(raise_exception=True)
+
+        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not auth_header:
+            return Response(
+                status=status.HTTP_401_UNAUTHORIZED,
+                data=err("Missing Authorization header."),
+            )
+
+        context = ToolContext(
+            auth_header=auth_header,
+            api_base=settings.CELLO_COPILOT_API_BASE,
+        )
+
+        try:
+            events = stream_agent(
+                messages=body.validated_data["messages"], context=context
+            )
+        except AgentConfigError as exc:
+            return Response(
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                data=err("The copilot is not configured: %s" % exc),
+            )
+
+        stream = sse.EventStream(events)
+        stream.start()
+
+        # Give the turn a moment to fail before committing to a status code.
+        # Most failures (missing key, bad key, unreachable endpoint) happen on
+        # the first provider call, so this catches them while a JSON error is
+        # still possible.
+        opening = stream.first()
+        if opening is not None and opening[0] == "error":
+            failure = opening[1]
+            if isinstance(failure, AgentConfigError):
+                return Response(
+                    status=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    data=err("The copilot is not configured: %s" % failure),
+                )
+            if isinstance(failure, AgentUpstreamError):
+                return Response(
+                    status=status.HTTP_502_BAD_GATEWAY,
+                    data=err(
+                        "The LLM provider could not be reached: %s" % failure
+                    ),
+                )
+            raise failure
+
+        response = StreamingHttpResponse(
+            stream.frames(), content_type="text/event-stream; charset=utf-8"
+        )
+        response["Cache-Control"] = "no-cache"
+        # uWSGI and nginx both buffer by default, which would hold the whole
+        # answer until the turn ends and defeat the point of streaming.
+        response["X-Accel-Buffering"] = "no"
+        return response

--- a/src/api-engine/requirements.txt
+++ b/src/api-engine/requirements.txt
@@ -27,3 +27,6 @@ tomli==2.0.1
 pygraphviz==1.5
 uWSGI==2.0.22
 requests==2.31.0
+# >=1.55.3 required: earlier releases pass proxies= to httpx.Client, which
+# httpx 0.28 removed, so constructing a client raises TypeError.
+openai==1.99.9


### PR DESCRIPTION
Part of #813, item 2 in the work split. Branched from `main` as @yeasy asked.

This is the backend half of the copilot. @Pranav-d33's panel in #832 is built
against the contract posted in #813 and currently has nothing to talk to, so
this is what unblocks it.

It replaces #817, which I opened before the MCP server landed and which
duplicated a good chunk of #797. I'll close that one.

## What it does

`POST /api/v1/copilot/chat`, JWT protected, answering as a `text/event-stream`.
Frames are `token`, `tool_call`, `tool_result` and a final `done`, exactly as
specified in #813. Five read-only tools: `list_nodes`, `list_channels`,
`list_chaincodes`, `list_organizations`, `check_health`. No write tools until
API-key auth and RBAC land (#764, #798), which is the posture we agreed on.

## Auth

The endpoint forwards the caller's own `Authorization` header to Cello's REST
API. The copilot therefore sees exactly what the logged-in user is allowed to
see, and permission scoping is inherited from the existing API instead of being
reimplemented here. There is no service account, so there is nothing to
over-privilege and no second set of credentials to rotate.

This is the one place the copilot differs from the MCP server in #797, which
logs in with its own account because stdio has no request to borrow a token
from.

## Layout

`client.py` holds the read-only REST queries. The caller passes in the API root
and a token, so the module has no opinion about where auth comes from and no
LLM or transport concepts in it. This is deliberately the module I described in
#813: once the ownership question is settled, `src/mcp-server/server.py` can
call the same five functions and we are down to one definition. It uses
`requests` rather than `httpx` because api-engine already pins `requests`; if
the module ends up owned by the MCP server instead, that swaps.

`tools.py` is the registry, descriptions and JSON schemas. `llm.py` is the
tool-calling loop, written as a generator of events. `sse.py` does frame
formatting. `views.py` handles validation, auth and error placement.

## Two things worth a look during review

**Why the loop runs on a worker thread.** The contract promises a `: ping`
comment every 15 seconds so proxies don't drop an idle connection. A turn that
calls a slow tool goes quiet for longer than that, and a plain synchronous
generator can't emit anything while it's blocked on the provider. So the loop
runs on a worker and the request thread reads from a queue with a timeout,
emitting a keepalive whenever the queue is empty. The worker only makes HTTP
calls and never touches the ORM, so it needs no database connection.

**Where errors land.** Until the first byte goes out the status line is still
ours: a bad body is a 400, missing auth a 401, a missing API key a 503 and an
unreachable provider a 502. After that the response is already a 200 and a
failure can only arrive as an `error` frame. The view waits up to 15 seconds
for the first event before committing, which covers the failures that happen on
the first provider call, and that is most of them.

There is also a blocking `run_agent` that drains the same generator, for
callers that only want the final answer. One loop, so the two can't drift.

## Config

Everything comes from the environment and nothing is committed. The endpoint
answers 503 until both a key and a model are set.

```
CELLO_COPILOT_LLM_API_KEY=...
CELLO_COPILOT_LLM_BASE_URL=https://api.deepseek.com
CELLO_COPILOT_LLM_MODEL=deepseek-chat
```

The base URL and the model pick the vendor together. Any endpoint speaking the
OpenAI chat-completions protocol works, so DeepSeek, OpenRouter, Together, Groq
and a local Ollama are config rather than code. Leaving the base URL empty falls
back to `api.openai.com`.

`CELLO_COPILOT_LLM_MODEL` deliberately has no default. #817 defaulted it to
`deepseek-chat` while the base URL defaulted to empty, which meant the
out-of-the-box combination asked OpenAI for a DeepSeek model and got a confusing
404. A missing model is now a 503 that says what to set.

## Testing

35 unit tests. Nothing touches the network or needs a key: the provider is
stubbed and the REST calls are mocked. The interesting ones cover reassembling
a tool call from deltas split across chunks, which is how providers actually
send them, the frame order the contract specifies, the keepalive firing while
the worker is quiet, and a failure landing as a status code before the stream
opens but as a frame after it.

Verified live against DeepSeek as well, with Cello's REST API stubbed and the
model real. The turn streams a preamble, calls `list_nodes`, and answers from
the result:

```
frames: [token x15, tool_call, tool_result, token x110, done]
REST calls: ['http://api/api/v1/nodes']
```

That is the part unit tests can't prove: real providers split tool-call
arguments across chunks in their own way, and the accumulator handles what
DeepSeek actually sends. The read-only prompt held too. Asked which peers were
down, the model named the stopped one and then said it could not start it and
pointed at the dashboard. The error path was exercised against two live
providers separately, and a 401 and a 429 both came back as a proper
`upstream_error` frame.

One thing for @Pranav-d33 that the contract does not spell out and probably
should: DeepSeek streams text *before* the `tool_call` frame and then resumes
after `tool_result`. So `token` frames can bracket a tool call rather than only
follow it. Appending them all into one assistant bubble is right, which is what
#832 looks like it already does, but it is worth being deliberate about.

Docker isn't running on my machine, so the endpoint tests ran against a minimal
Django config rather than the real project settings. CI runs them properly.

## One question still open

#813 has an unanswered question about which side owns the shared client module,
and whether refactoring `server.py` to use it should be its own PR. Nothing here
blocks on that: `client.py` is written to be moved, and moving it is one commit.
I went ahead so #832 stops waiting.

## Also in this PR

A workflow that runs the api-engine unit tests on push and PR. There isn't one
today, so nothing on the Python side is checked by CI beyond lint.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPidKEmDqyBWputiKrHsQF
